### PR TITLE
Install lacking import modules -- bugfix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def main():
           platforms='Linux',
           url='https://github.com/yniknafs/taco',
           ext_modules=cythonize(extensions),
-          packages=['taco'],
+          packages=['taco', 'taco.lib', 'taco.lib.bx'],
           scripts=['taco/taco_run.py'])
 
 if __name__ == '__main__':


### PR DESCRIPTION
'packages' doesn't follow the directories down and include all of the subfolders and submodules. This fixes the problem by including all of the submodules. 

If you run the previous code, it doesn't find the 'lib' folder and results in:

```
Traceback (most recent call last):
  File "taco_run.py", line 11, in <module>
    from taco.lib.run import Run
ImportError: No module named lib.run
```
